### PR TITLE
removing recordtypeid overwrite as it's now allowing multiple recordt…

### DIFF
--- a/src/commands/texei/data/import.ts
+++ b/src/commands/texei/data/import.ts
@@ -119,11 +119,6 @@ export default class Import extends SfdxCommand {
         }   
       }
 
-      // Replace Record Types, if any
-      if (recTypeInfos.size > 0) {
-        sobject.RecordTypeId = recTypeInfos.get(sobject.RecordTypeId);
-      }
-
       // If object is PricebookEntry, use standard price book from target org
       if (sobjectName === 'PricebookEntry' && sobject.Pricebook2Id === 'StandardPriceBook') {
         sobject.Pricebook2Id = standardPriceBookId;


### PR DESCRIPTION
In the event we want to use multiple record type ids on a sobject json file such as below, the lines removed try to populate the RecordTypeId field with what seems to be the DeveloperName of the record type.  There may be something I'm not familiar with regarding certain expectations of record types and texei so please let me know if I need to take another look with a different perspective

`  
[ 
  {
      "attributes": {
        "type": "Account",
        "referenceId": "AccountRef1"
      },
      "Name": "Sample Account for Entitlements",
      "Type": null,
      "RecordTypeId": "01111000000B48CAAS"
   },
    {
      "attributes": {
        "type": "Account",
        "referenceId": "AccountRef2"
      },
      "Name": "Sample Account for even more Entitlements",
      "Type": null,
      "RecordTypeId": "02222000000B48CABW"
    }
]
`